### PR TITLE
Fix substitutions for Blessing strengths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,6 @@ dist
 .svelte-kit
 
 # End of https://www.toptal.com/developers/gitignore/api/node
+
+# WebStorm / IntelliJ configs
+.idea/

--- a/extension/bundle.js
+++ b/extension/bundle.js
@@ -35080,6 +35080,34 @@
   function Title({ children }) {
     return /* @__PURE__ */ (0, import_jsx_runtime6.jsx)("div", { className: "item-title", children });
   }
+  function lerp(min, max, input) {
+    let clampedInput = Math.min(Math.max(input, 1), 0);
+    return min * (1 - clampedInput) + max * clampedInput;
+  }
+  function steppedLerp(range, input) {
+    let clampedInput = Math.min(Math.max(input, 1), 0);
+    let interpolatedValue = lerp(1, range.length, clampedInput);
+    let clampedInterpolatedValue = Math.min(Math.max(interpolatedValue, range.length), 1);
+    return range[Math.round(clampedInterpolatedValue) - 1];
+  }
+  function calculateGadgetTraitStrength(trait_id, value) {
+    let traitStrength = "";
+    switch (trait_id) {
+      case "content/items/traits/gadget_inate_trait/trait_inate_gadget_toughness":
+        traitStrength = lerp(0.05, 0.2, value).toFixed(2);
+        break;
+      case "content/items/traits/gadget_inate_trait/trait_inate_gadget_health":
+        traitStrength = lerp(0.05, 0.2, value).toFixed(2);
+        break;
+      case "content/items/traits/gadget_inate_trait/trait_inate_gadget_health_segment":
+        traitStrength = steppedLerp([1, 2, 3], value).toString();
+        break;
+      case "content/items/traits/gadget_inate_trait/trait_inate_gadget_stamina":
+        traitStrength = "1";
+        break;
+    }
+    return traitStrength;
+  }
   var ratingColor = {
     1: "grey",
     2: "#36AE7C",
@@ -35253,11 +35281,17 @@
               /* @__PURE__ */ (0, import_jsx_runtime6.jsx)("div", { className: "perks", children: offer.description.overrides.traits.map((trait) => {
                 let { description: desc, display_name } = localisation_default[trait.id];
                 let descVals = items[trait.id]?.description_values.filter((v) => v.rarity === trait.rarity.toString());
-                let description = descVals?.length ? descVals.reduce((str, descVal) => {
-                  let replace = `{${descVal?.string_key}:%s}`;
-                  str = str.replace(replace, descVal?.string_value ?? "");
-                  return str;
-                }, desc) : desc;
+                let description = desc;
+                if (descVals?.length) {
+                  description = descVals.reduce((str, descVal) => {
+                    let replace = `{${descVal?.string_key}:%s}`;
+                    str = str.replaceAll(replace, descVal?.string_value ?? "");
+                    return str;
+                  }, desc);
+                } else if (offer.description.type === "gadget" && trait.value !== void 0) {
+                  let replace = /{\w+:%s}/g;
+                  description = description.replaceAll(replace, calculateGadgetTraitStrength(trait.id, trait.value) ?? "");
+                }
                 return /* @__PURE__ */ (0, import_jsx_runtime6.jsxs)("div", { className: "perk", children: [
                   /* @__PURE__ */ (0, import_jsx_runtime6.jsx)("div", { className: "perk-rarity", children: raritySymbol[trait.rarity] }),
                   /* @__PURE__ */ (0, import_jsx_runtime6.jsx)(Text, { children: `${display_name}: ${description}` })

--- a/src/components/Store.tsx
+++ b/src/components/Store.tsx
@@ -16,6 +16,47 @@ function Title({ children }: { children: ReactNode }) {
 	return <div className="item-title">{children}</div>
 }
 
+// Linearly interpolate input between min and max. E.g. lerp(1, 2, 0.5) returns 1.5
+function lerp(min: number, max: number, input: number): number {
+	// Make sure input is a unit interval (0 <= n <= 1)
+	let clampedInput = Math.min(Math.max(input, 1.0), 0.0);
+	return min * (1 - clampedInput) + max * clampedInput
+}
+
+// Linearly interpolate to the nth element of an array.
+// E.g. steppedLerp(['a','b'], 0.5) returns 'b' due to rounding.
+function steppedLerp(range: number[], input: number): number {
+	// Make sure input is a unit interval (0 <= n <= 1)
+	let clampedInput = Math.min(Math.max(input, 1.0), 0.0);
+	let interpolatedValue = lerp(1, range.length, clampedInput)
+
+	// Make sure that the value will always lie inside valid indexes of the range.
+	let clampedInterpolatedValue = Math.min(Math.max(interpolatedValue, range.length), 1)
+	return range[Math.round(clampedInterpolatedValue) - 1] as number
+}
+
+// Calculate the in-game value for gadget traits. These are usually some sort of
+// linear interpolation, but some are constants and some are scaled to integers instead.
+// Min/Max and logic inferred from https://github.com/Cortex-Network/Darkmass-Data-Mining/blob/main/All%20.lua%20Scripts/scripts/settings/buff/gadget_buff_templates.lua
+function calculateGadgetTraitStrength(trait_id: string, value: number): string {
+	let traitStrength = ''
+	switch (trait_id) {
+		case 'content/items/traits/gadget_inate_trait/trait_inate_gadget_toughness':
+			traitStrength = lerp(0.05, 0.2, value).toFixed(2)
+			break
+		case 'content/items/traits/gadget_inate_trait/trait_inate_gadget_health':
+			traitStrength = lerp(0.05, 0.2, value).toFixed(2)
+			break
+		case 'content/items/traits/gadget_inate_trait/trait_inate_gadget_health_segment':
+			traitStrength = steppedLerp([1, 2, 3], value).toString()
+			break
+		case 'content/items/traits/gadget_inate_trait/trait_inate_gadget_stamina':
+			traitStrength = '1'
+			break
+	}
+	return traitStrength
+}
+
 const ratingColor = {
 	1: 'grey', // grey
 	2: "#36AE7C", // green
@@ -247,13 +288,21 @@ export function Store({ character, sortOption, filterOption }: { character?: Cha
 											<div className="perks">
 												{offer.description.overrides.traits.map(trait => {
 													let { description: desc, display_name } = localisation[trait.id]
+
 													let descVals = items![trait.id]?.description_values.filter(v => v.rarity === trait.rarity.toString())
-													let description = descVals?.length ?
-														descVals.reduce((str, descVal) => {
+													let description = desc
+													if (descVals?.length) {
+														description = descVals.reduce((str, descVal) => {
 															let replace = `{${descVal?.string_key}:%s}`
-															str = str.replace(replace, descVal?.string_value ?? '')
+															// Use replaceAll not replace for things like Limbsplitter
+															str = str.replaceAll(replace, descVal?.string_value ?? '')
 															return str
-														}, desc) : desc
+														}, desc)
+													} else if (offer.description.type === 'gadget' && trait.value !== undefined) {
+														// Gadgets (so far!) only ever have one trait, so we don't need to map/reduce anything here
+														let replace = /{\w+:%s}/g
+														description = description.replaceAll(replace, calculateGadgetTraitStrength(trait.id, trait.value) ?? '')
+													}
 
 													return <div className="perk" key={trait.id + trait.rarity}>
 														<div className="perk-rarity">


### PR DESCRIPTION
Fixes #11

Not sure how much of this you want to push into utils.tsx or similar - it felt like you'd tried to keep that file for high level utils, so have tried to keep the stuff relevant to the Store in Store.tsx.

Also fixed a bug for the Limbsplitter blessing, it needed {power_level:%s} replacing twice, hence replaceAll instead of just replace.