### PR TITLE
Allow using non-array values for filter rules

### DIFF
--- a/src/components/Store.tsx
+++ b/src/components/Store.tsx
@@ -171,13 +171,16 @@ function filterFunc(
     return
   }
 
+  let arr: string[]
+
   var statRoll =
     offer.description.overrides.base_stats?.reduce((sum, stat) => {
       return Math.round(sum + stat.value * 100)
     }, 0) || 0
 
   var found = targets.find(function (target) {
-    if (target.character && !target.character.includes(char.archetype)) {
+    arr = typeof target.character === 'string' ? [target.character] : target.character
+    if (target.character && !arr.includes(char.archetype)) {
       return false
     }
 
@@ -185,15 +188,17 @@ function filterFunc(
       return false
     }
 
-    if (
-      target.item &&
-      !target.item.find((element) =>
-        localisation[offer.description.id].display_name.match(
-          new RegExp(element, "i")
+    if (target.item) {
+      arr = typeof target.item === 'string' ? [target.item] : target.item
+      if (
+        !arr.find((element) =>
+          localisation[offer.description.id].display_name.match(
+            new RegExp(element, "i")
+          )
         )
-      )
-    ) {
-      return false
+      ) {
+        return false
+      }
     }
 
     if (target.minStats && target.minStats > statRoll) {
@@ -207,10 +212,11 @@ function filterFunc(
     }
 
     if (target.blessing) {
+      arr = typeof target.blessing === 'string' ? [target.blessing] : target.blessing
       if (
         !offer.description.overrides.traits.find(function (blessing) {
           if (
-            !target.blessing.find((element) =>
+            !arr.find((element) =>
               localisation[blessing.id].display_name.match(
                 new RegExp(element, "i")
               )
@@ -239,10 +245,11 @@ function filterFunc(
     }
 
     if (target.perk) {
+      arr = typeof target.perk === 'string' ? [target.perk] : target.perk
       if (
         !offer.description.overrides.perks.find(function (perk) {
           if (
-            !target.perk.find((element) =>
+            !arr.find((element) =>
               localisation[perk.id].description.match(new RegExp(element, "i"))
             )
           ) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,7 +31,7 @@ export interface Character {
   id: string
   name: string
   gender: string
-  archetype: "veteran" | "zealot" | "psyker" | "ogryn"
+  archetype: ClassType
   specialization: string
   level: number
 }
@@ -206,8 +206,11 @@ interface PlayerItems {
   version: string
 }
 
+export const CLASS_TYPES = ["veteran", "zealot", "psyker", "ogryn"] as const
+export type ClassType = typeof CLASS_TYPES[number]
+
 export interface FilterRule {
-  character?: ("veteran" | "zealot" | "psyker" | "ogryn")[]
+  character?: ClassType[] | ClassType
   item?: string[] | string
   blessing?: string[] | string
   perk?: string[] | string

--- a/src/types.ts
+++ b/src/types.ts
@@ -208,10 +208,10 @@ interface PlayerItems {
 
 export interface FilterRule {
   character?: ("veteran" | "zealot" | "psyker" | "ogryn")[]
-  item?: string[]
-  blessing?: string[]
-  perk?: string[]
-  store?: StoreType[]
+  item?: string[] | string
+  blessing?: string[] | string
+  perk?: string[] | string
+  store?: StoreType[] | string
   minBlessingRarity?: number
   minPerkRarity?: number
   minStats?: number


### PR DESCRIPTION
Automatic formatting of the filter rules made me think that maybe its finally time to not force people to use arrays for everything to avoid unnecessary verbosity on the configuration. 

Initial thought was that doing so might make the filter code too branchy, but maybe this would be one way to do it without code being too ugly.