### PR TITLE
Workaround for Chrome textarea. Fixes #41

### DIFF
--- a/src/components/RuleBasedFilters.tsx
+++ b/src/components/RuleBasedFilters.tsx
@@ -67,6 +67,16 @@ export function RuleBasedFilters(props: Props) {
             className="rule-input"
             name="match-rules-area"
             rows={15}
+            onKeyDown={(event) => {
+                // Workaround for Chrome specific bug: https://github.com/danreeves/dt-exchange/issues/41
+                if (event.key === 'PageUp' || event.key === 'PageDown') {
+                  console.log(event.target)
+                  const cursorPosition = event.key === 'PageUp' ? 0 : event.target.textLength;
+              
+                  event.preventDefault();
+                  event.target.setSelectionRange(cursorPosition, cursorPosition);
+                }
+            }}
             onChange={(e) => {
               if (textAreaRef.current) {
                 textAreaRef.current.setCustomValidity("")

--- a/src/components/RuleBasedFilters.tsx
+++ b/src/components/RuleBasedFilters.tsx
@@ -70,7 +70,6 @@ export function RuleBasedFilters(props: Props) {
             onKeyDown={(event) => {
                 // Workaround for Chrome specific bug: https://github.com/danreeves/dt-exchange/issues/41
                 if (event.key === 'PageUp' || event.key === 'PageDown') {
-                  console.log(event.target)
                   const cursorPosition = event.key === 'PageUp' ? 0 : event.target.textLength;
               
                   event.preventDefault();


### PR DESCRIPTION
#41 mentions a bug where pageup and pagedown breaks the whole page layout. This seems to be 6 year old known bug in Chrome, discussed on this SO topic: https://stackoverflow.com/questions/17808854/pressing-pageup-while-in-textarea-moves-website-out-of-the-window

This commit implements the workaround mentioned as a solution. Firefox continues to work normally, on Chrome it prevents the page breaking issue but also doesn't scroll the textbox (does move the cursor position though).

If anyone has good ideas how to fix this in a way that still allows pageup and pagedown to work feel free to implement a better fix.