### PR TITLE
Better account name handling

### DIFF
--- a/src/hooks/useFetcher.ts
+++ b/src/hooks/useFetcher.ts
@@ -1,13 +1,13 @@
 import { useMemo, useRef } from "react"
 import { isEqual } from "lodash"
-import { createFetcher, getLocalStorage } from "../utils"
+import { createFetcher, getFatSharkUser } from "../utils"
 import type { User } from "../types"
 
 type Fetcher = <T>(path: string) => Promise<T>
 
 export function useFetcher(): Fetcher {
   let userRef = useRef<User>()
-  let user = getLocalStorage<User>("user")
+  let user = getFatSharkUser()
 
   if (!isEqual(user, userRef.current)) {
     userRef.current = user

--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -1,5 +1,4 @@
 import { useCallback, useState } from "react"
-import { safeParseJSON } from "../utils"
 
 const NAMESPACE = "armoury-exchange-"
 
@@ -10,7 +9,7 @@ function setLocalStorage(key: string, value: unknown) {
 }
 
 function getLocalStorage<T>(key: string): T | undefined {
-  return safeParseJSON<T>(localStorage.getItem(makeKey(key)) ?? "undefined")
+  return JSON.parse(localStorage.getItem(makeKey(key)) ?? "undefined")
 }
 
 export function useLocalStorage<T>(

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,30 +1,19 @@
 import test from "ava"
-import { Buffer } from "buffer/"
 import { safeUserParse } from "./utils"
 
 let userNames = [
-  `【パンツ】Pantsu`,
-  `🎃 ASH  П (◣_◢) П  🎃`,
-  `七曜曜`,
-  `Dunesca ʕ•͡ᴥ•ʔ`,
+  `【パンツ】Pantsu#1234`,
+  `🎃 ASH  П (◣_◢) П  🎃#1234`,
+  `七曜曜#1234`,
+  `Dunesca ʕ•͡ᴥ•ʔ#1234`,
+  `Deadsiesthe•̪̀●́#1234`,
+  `Deadsiesthe"*�#1234`
 ]
 
-function toB64(str: string): string {
-  return Buffer.from(str, "ascii").toString("base64")
-}
-
-function fromB64(str: string): string {
-  return Buffer.from(str, "base64").toString()
-}
-
-function encode(obj: Record<string, unknown>): string {
-  return fromB64(toB64(JSON.stringify(obj)))
-}
-
 for (let user of userNames) {
-  test(`safeUserParse can decode special user names: ${user}`, (t) => {
+  test(`safeUserParse can parse special user names: ${user}`, (t) => {
     const TestAccessToken = "This Should Be Returned"
-    let userString = encode({ AccessToken: TestAccessToken, AccountName: user })
+    let userString = `{\"AccessToken\": \"${TestAccessToken}\", \"AccountName\":\"${user}\"}`
     let decoded = safeUserParse(userString)
     t.not(decoded, undefined)
     t.is(decoded!.AccessToken, TestAccessToken)
@@ -38,20 +27,21 @@ for (let user of userNames) {
 
 test(" safely removes bad usernames anywhere in json", (t) => {
   const TestAccessToken = "This Should Be Returned"
-  const user = userNames[0]
-  let strings = [
-    encode({ AccountName: user }),
-    encode({ AccessToken: TestAccessToken, AccountName: user }),
-    encode({ AccountName: user, AccessToken: TestAccessToken }),
-    encode({ AccessToken: TestAccessToken, AccountName: user, RefreshToken: TestAccessToken }),
-  ]
-  for (let str of strings) {
-    let decoded = safeUserParse(str)
-    t.not(decoded, undefined)
-    t.not(decoded?.AccountName, undefined)
-    t.not(decoded?.AccountName, '')
-    if (decoded?.AccountName) {
-      t.is(/[\w-#]+/.test(decoded?.AccessToken), true)
+  for (let user of userNames) {
+    let strings = [
+      `{\"AccountName\": \"${user}\"}`,
+      `{\"AccessToken\":\"${TestAccessToken}\", \"AccountName\":\"${user}\"}`,
+      `{\"AccountName\":\"${user}\", \"AccessToken\":\"${TestAccessToken}\"}`,
+      `{\"RefreshToken\":\"${TestAccessToken}\", \"AccountName\":\"${user}\", \"AccessToken\":\"${TestAccessToken}\"}`
+    ]
+    for (let str of strings) {
+      let decoded = safeUserParse(str)
+      t.not(decoded, undefined)
+      t.not(decoded?.AccountName, undefined)
+      t.not(decoded?.AccountName, '')
+      if (decoded?.AccountName) {
+        t.is(/[\w-#]+/.test(decoded?.AccessToken), true)
+      }
     }
   }
 })

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,6 +1,6 @@
 import test from "ava"
-import { safeParseJSON } from "./utils"
 import { Buffer } from "buffer/"
+import { safeUserParse } from "./utils"
 
 let userNames = [
   `【パンツ】Pantsu`,
@@ -22,28 +22,36 @@ function encode(obj: Record<string, unknown>): string {
 }
 
 for (let user of userNames) {
-  test(`safeParseJSON can decode special user names: ${user}`, (t) => {
-    const TestValue = "This Should Be Returned"
-    let userString = encode({ TestValue, AccountName: user })
-    let decoded = safeParseJSON<{ AccountName: string; TestValue: string }>(
-      userString
-    )
+  test(`safeUserParse can decode special user names: ${user}`, (t) => {
+    const TestAccessToken = "This Should Be Returned"
+    let userString = encode({ AccessToken: TestAccessToken, AccountName: user })
+    let decoded = safeUserParse(userString)
     t.not(decoded, undefined)
-    t.is(decoded!.TestValue, TestValue)
+    t.is(decoded!.AccessToken, TestAccessToken)
+    t.not(decoded?.AccountName, undefined)
+    t.not(decoded?.AccountName, '')
+    if (decoded?.AccountName) {
+      t.is(/[\w-#]+/.test(decoded?.AccessToken), true)
+    }
   })
 }
 
 test(" safely removes bad usernames anywhere in json", (t) => {
-  const TestValue = "This Should Be Returned"
+  const TestAccessToken = "This Should Be Returned"
   const user = userNames[0]
   let strings = [
     encode({ AccountName: user }),
-    encode({ TestValue, AccountName: user }),
-    encode({ AccountName: user, TestValue }),
-    encode({ TestValue, AccountName: user, TestValue2: TestValue }),
+    encode({ AccessToken: TestAccessToken, AccountName: user }),
+    encode({ AccountName: user, AccessToken: TestAccessToken }),
+    encode({ AccessToken: TestAccessToken, AccountName: user, RefreshToken: TestAccessToken }),
   ]
   for (let str of strings) {
-    let decoded = safeParseJSON<{ AccountName: string; TestValue: string }>(str)
+    let decoded = safeUserParse(str)
     t.not(decoded, undefined)
+    t.not(decoded?.AccountName, undefined)
+    t.not(decoded?.AccountName, '')
+    if (decoded?.AccountName) {
+      t.is(/[\w-#]+/.test(decoded?.AccessToken), true)
+    }
   }
 })

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -6,42 +6,52 @@ let userNames = [
   `🎃 ASH  П (◣_◢) П  🎃#1234`,
   `七曜曜#1234`,
   `Dunesca ʕ•͡ᴥ•ʔ#1234`,
-  `Deadsiesthe•̪̀●́#1234`,
-  `Deadsiesthe"*�#1234`
+  `Deadsiesthe•̪̀●́#1234`
 ]
+
+function toB64(str: string): string {
+  return Buffer.from(str, "ascii").toString("base64")
+}
+
+function fromB64(str: string): string {
+  return Buffer.from(str, "base64").toString()
+}
+
+// @danreeves did a great job of figuring out how FS are mangling these strings,
+// so we're replicating the process here. In particular, some elements like
+// Deadsiesthe•̪̀●́#1234 get mangled to Deadsiesthe"*�#1234
+function mangle(obj: Record<string, unknown>): string {
+  return fromB64(toB64(JSON.stringify(obj)))
+}
 
 for (let user of userNames) {
   test(`safeUserParse can parse special user names: ${user}`, (t) => {
     const TestAccessToken = "This Should Be Returned"
-    let userString = `{\"AccessToken\": \"${TestAccessToken}\", \"AccountName\":\"${user}\"}`
+    let userString = mangle({AccessToken: TestAccessToken, AccountName:user})
     let decoded = safeUserParse(userString)
     t.not(decoded, undefined)
     t.is(decoded!.AccessToken, TestAccessToken)
     t.not(decoded?.AccountName, undefined)
     t.not(decoded?.AccountName, '')
-    if (decoded?.AccountName) {
-      t.is(/[\w-#]+/.test(decoded?.AccessToken), true)
-    }
+    t.is(/[\w-#]+/.test(decoded!.AccessToken), true)
   })
 }
 
 test(" safely removes bad usernames anywhere in json", (t) => {
   const TestAccessToken = "This Should Be Returned"
   for (let user of userNames) {
-    let strings = [
-      `{\"AccountName\": \"${user}\"}`,
-      `{\"AccessToken\":\"${TestAccessToken}\", \"AccountName\":\"${user}\"}`,
-      `{\"AccountName\":\"${user}\", \"AccessToken\":\"${TestAccessToken}\"}`,
-      `{\"RefreshToken\":\"${TestAccessToken}\", \"AccountName\":\"${user}\", \"AccessToken\":\"${TestAccessToken}\"}`
+    let objs = [
+      {AccountName: user},
+      {AccessToken: TestAccessToken, AccountName: user},
+      {AccountName: user, AccessToken: TestAccessToken},
+      {RefreshToken: TestAccessToken, AccountName: user, AccessToken: TestAccessToken}
     ]
-    for (let str of strings) {
-      let decoded = safeUserParse(str)
+    for (let obj of objs) {
+      let decoded = safeUserParse(mangle(obj))
       t.not(decoded, undefined)
       t.not(decoded?.AccountName, undefined)
       t.not(decoded?.AccountName, '')
-      if (decoded?.AccountName) {
-        t.is(/[\w-#]+/.test(decoded?.AccessToken), true)
-      }
+      t.is(/[\w-#]+/.test(decoded!.AccessToken), true)
     }
   }
 })

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -40,7 +40,7 @@ export function safeUserParse(input: string): User | undefined {
     try {
       // If the user contains a special character, lets just rip that out, since there's
       // no logic I could figure out to repair the AccountName from the resulting mess
-      let accountNameRegex = /"AccountName":"(.*)"[,}]/g
+      let accountNameRegex = /"AccountName":"(.*)#\d{4}"[,}]/g
 
       let matches = accountNameRegex.exec(input)
       let accountName: string

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -40,7 +40,7 @@ export function safeUserParse(input: string): User | undefined {
     try {
       // If the user contains a special character, lets just rip that out, since there's
       // no logic I could figure out to repair the AccountName from the resulting mess
-      let accountNameRegex = /"AccountName":"(.*)#\d{4}"[,}]/g
+      let accountNameRegex = /"AccountName":\W?"(.*)#\d{4}"[,}]/g
 
       let matches = accountNameRegex.exec(input)
       let accountName: string

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -28,52 +28,21 @@ export function createFetcher(user: User) {
   }
 }
 
-export function safeParseJSON<T>(jsonString: string): T | undefined {
-  let input = jsonString
-  let parsed: T | undefined
-
-  let accountNameRe =
-    /"AccountName":".*",|,"AccountName":".*"|"AccountName":".*"/
-
-  try {
-    parsed = JSON.parse(input)
-  } catch {
-    try {
-      parsed = JSON.parse(input.replace(accountNameRe, ""))
-    } catch {
-      warn("User could not be decoded")
-      parsed = undefined
-    }
-  }
-
-  return parsed
-}
-
-export function getFatSharkUser(): User | undefined {
-  // This key is set by FatShark, so it's not in our namespace.
-  let userEncoded = localStorage.getItem('user')
-  if (!userEncoded) {
-    warn("No user present in localstorage")
-    return undefined
-  }
-
-  // The user is a base64 encoded version of the response to /queue/refresh
-  let userDecoded = Buffer.from(userEncoded, 'base64').toString()
-
+export function safeUserParse(input: string): User | undefined {
   // FS currently have a bug where non-ASCII characters are utterly mangled by their
   // backend, and the "AccountName" field of the user JSON can contain very weird
   // characters. It may contain unescaped double quotes, control characters, or
   // even bonkers unicode characters like \uFFFD.
   try {
     // Most users will work first time, so lets try that first
-    return JSON.parse(userDecoded)
+    return JSON.parse(input)
   } catch (error) {
     try {
       // If the user contains a special character, lets just rip that out, since there's
       // no logic I could figure out to repair the AccountName from the resulting mess
       let accountNameRegex = /"AccountName":"(.*)"[,}]/g
 
-      let matches = accountNameRegex.exec(userDecoded)
+      let matches = accountNameRegex.exec(input)
       let accountName: string
       // Make sure the response actually included an AccountName field
       if (matches && matches[1]) {
@@ -87,14 +56,28 @@ export function getFatSharkUser(): User | undefined {
       // Remove all non-alphanumerics, plus hyphen and hash. We don't show this field anyway.
       let safeAccountName = accountName.replace(/[^\w-#]/g, "?")
       // Replace the crazy characters with something safe
-      userDecoded = userDecoded.replace(accountName, safeAccountName)
+      input = input.replace(accountName, safeAccountName)
 
-      return JSON.parse(userDecoded)
+      return JSON.parse(input)
     } catch (error) {
       warn("User could not be decoded")
       return undefined
     }
   }
+}
+
+export function getFatSharkUser(): User | undefined {
+  // This key is set by FatShark, so it's not in our namespace.
+  let userEncoded = localStorage.getItem('user')
+  if (!userEncoded) {
+    warn("No user present in localstorage")
+    return undefined
+  }
+
+  // The user is a base64 encoded version of the response to /queue/refresh
+  let userDecoded = Buffer.from(userEncoded, 'base64').toString()
+
+  return safeUserParse(userDecoded)
 }
 
 export function log(msg: string) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -49,13 +49,52 @@ export function safeParseJSON<T>(jsonString: string): T | undefined {
   return parsed
 }
 
-export function getLocalStorage<T>(key: string): T | undefined {
-  const encoded = localStorage.getItem(key)
-  const decoded = encoded
-    ? safeParseJSON<T>(Buffer.from(encoded, "base64").toString())
-    : undefined
+export function getFatSharkUser(): User | undefined {
+  // This key is set by FatShark, so it's not in our namespace.
+  let userEncoded = localStorage.getItem('user')
+  if (!userEncoded) {
+    warn("No user present in localstorage")
+    return undefined
+  }
 
-  return decoded
+  // The user is a base64 encoded version of the response to /queue/refresh
+  let userDecoded = Buffer.from(userEncoded, 'base64').toString()
+
+  // FS currently have a bug where non-ASCII characters are utterly mangled by their
+  // backend, and the "AccountName" field of the user JSON can contain very weird
+  // characters. It may contain unescaped double quotes, control characters, or
+  // even bonkers unicode characters like \uFFFD.
+  try {
+    // Most users will work first time, so lets try that first
+    return JSON.parse(userDecoded)
+  } catch (error) {
+    try {
+      // If the user contains a special character, lets just rip that out, since there's
+      // no logic I could figure out to repair the AccountName from the resulting mess
+      let accountNameRegex = /"AccountName":"(.*)"[,}]/g
+
+      let matches = accountNameRegex.exec(userDecoded)
+      let accountName: string
+      // Make sure the response actually included an AccountName field
+      if (matches && matches[1]) {
+        accountName = matches[1]
+      } else {
+        // If it didn't, and it failed the first parse, give up here.
+        warn("User could not be decoded, unable to repair accountName")
+        return undefined
+      }
+
+      // Remove all non-alphanumerics, plus hyphen and hash. We don't show this field anyway.
+      let safeAccountName = accountName.replace(/[^\w-#]/g, "?")
+      // Replace the crazy characters with something safe
+      userDecoded = userDecoded.replace(accountName, safeAccountName)
+
+      return JSON.parse(userDecoded)
+    } catch (error) {
+      warn("User could not be decoded")
+      return undefined
+    }
+  }
 }
 
 export function log(msg: string) {


### PR DESCRIPTION
Fixes #45 

![image](https://user-images.githubusercontent.com/15087570/210933876-05f41979-3a4f-4918-9a55-0802918cb786.png)

I *believe*, but can't confirm, that FS assigns every AccountName a discriminator, so I'm using that as a warning of the end of the AccountName.

If someone has a user from some other platform or something that doesn't have this, please let me know as I'll need to rethink.

Also, this PR has some tidying involved with the "get user from local storage" function, since it was conflicting with a non-exported function from useLocalStorage.
