### PR TITLE
Add ability to filter by item type

### DIFF
--- a/docs/rule-based-filtering.md
+++ b/docs/rule-based-filtering.md
@@ -48,6 +48,9 @@ Array filters (`[]`) allow listing **one or more** matches. If the item matches 
 - `perk`: perk name(s)
   - possible values: any part of the perks **description**
   - example: `"perk": ["Sprint Efficiency", "Critical Hit Chance"]`
+- `type`: item type
+  - possible values: `curio`, `ranged` or `melee`
+  - example: `"type": ["melee", "ranged"]`
 
 ### Numeric
 
@@ -97,7 +100,7 @@ Lets consider the following example:
     "blessing": "Power Cycler"
   },
   {
-    "item": "Kantrael MG XII Infantry Lasgun",
+    "item": ["Kantrael MG XII Infantry Lasgun", "Recon Lasgun"],
     "blessing": [
       "Infernus",
       "Ghost"
@@ -112,7 +115,7 @@ Lets consider the following example:
   },
   {
     "character": "veteran",
-    "item": ["(Reliquary)", "(Caged)", "(Casket)"],
+    "type": "curio",
     "blessing": "Endurance",
     "perk": "Block Efficiency",
     "minRating": 80
@@ -137,7 +140,7 @@ This would match any Power Sword with the blessing `Power Cycler`. Since there i
 
 ```json
 {
-  "item": "Kantrael MG XII Infantry Lasgun",
+  "item": ["Kantrael MG XII Infantry Lasgun", "Recon Lasgun"],
   "blessing": [
     "Infernus",
     "Ghost"
@@ -145,7 +148,7 @@ This would match any Power Sword with the blessing `Power Cycler`. Since there i
 }
 ```
 
-Similar to the first one, but here we're looking for specific variation of the Infantry Lasgun, and are required to write down more specific name. Variations that would also work are things like `Kantrael MG XII` or `XII Infantry Lasgun`. 
+Similar to the first one, but here we're looking either for a specific variation of the Infantry Lasgun or any type of Recon Lasgun. In order to match specific Infrantry Lasgun variant we are required to write down more specific name. It's not required to write the whole name, variations that would also work are things like `Kantrael MG XII` or `XII Infantry Lasgun`. 
 
 In addition we're looking for more than one possible blessing, so they're inside square brackets. Note that while the filter spans multiple lines, it's exactly same as `"blessing": ["Infernus","Ghost"]`.
 
@@ -175,11 +178,11 @@ This rule will match any item in the hourly shop that has blessing of rarity 3 o
 ```json
 {
   "character": "veteran",
-  "item": ["(Reliquary)", "(Caged)", "(Casket)"],
+  "type": "curio",
   "blessing": "Endurance",
   "perk": "Block Efficiency",
   "minRating": 80
 }
 ```
 
-First of all this rule only matches items that are available to your `veteran` character. While there isn't a specific filter to match Curios specifically, `"item": ["(Reliquary)", "(Caged)", "(Casket)"]` should do just that.
+This would look for specific kind of curios that are available to your `veteran` character.

--- a/src/components/Store.tsx
+++ b/src/components/Store.tsx
@@ -171,7 +171,8 @@ function filterFunc(
   char: Character | undefined,
   storeType: StoreType,
   offer: Personal,
-  targets: FilterRule[]
+  targets: FilterRule[],
+  items: Items
 ) {
   if (!char) {
     return
@@ -202,9 +203,32 @@ function filterFunc(
       }
     }
 
+    if (target.type) {
+      arr = typeof target.type === 'string' ? [target.type] : target.type
+      if (
+        !arr.find(function(element){
+          switch (items[offer.description.id]?.item_type) {
+            case "WEAPON_RANGED":
+              return target.type.toLowerCase() == "ranged" ? true : false
+            case "WEAPON_MELEE":
+              return target.type.toLowerCase() == "melee" ? true : false
+            case "GADGET":
+              return target.type.toLowerCase() == "curio" ? true : false
+            default:
+              return false
+          }
+        })
+      ) {
+        return false
+      }
+    }
+
+
+
     if (target.minStats && target.minStats > offer.description.overrides.baseItemLevel) {
       return false
     }
+
     if (
       target.minRating &&
       target.minRating > offer.description.overrides.itemLevel
@@ -316,7 +340,7 @@ export function Store({
       targets = filterRules
       if (targets.length > 0) {
         store.personal.map(function (offer) {
-          filterFunc(character, storeType, offer, targets)
+          filterFunc(character, storeType, offer, targets, items)
         })
       }
     } catch (e) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -212,6 +212,7 @@ export type ClassType = typeof CLASS_TYPES[number]
 export interface FilterRule {
   character?: ClassType[] | ClassType
   item?: string[] | string
+  type?: string[] | string
   blessing?: string[] | string
   perk?: string[] | string
   store?: StoreType[] | string


### PR DESCRIPTION
Remembered that since we already have the item type available as dropdown it's simple to add it as a filter rule as well. This removes the need to do complex rules for curios etc.