### PR TITLE
Add support for defining how to color items based on which rule matches

### DIFF
--- a/docs/rule-based-filtering.md
+++ b/docs/rule-based-filtering.md
@@ -30,6 +30,10 @@ where each `FILTER` is some type of `"key": value` pair, explained further below
 
 Note: The format is called JSON and it can be quite strict with formatting. If you feel like your configuration should work but it doesn't, it's usually good idea to check with a tool like https://jsoneditoronline.org/ to make sure you're not missing comma or a quote from somewhere.
 
+## Evaluation order
+
+Rules are checked in the order they're defined. Item is (only) considered to be a match for the topmost rule it matches. While this doesn't matter in many cases, it does matter if you're using some of the rule-specific customization options like `color`. This means that usually you'll want your more specific rules be at the top and ones that match wider set of items at the bottom.
+
 ## Supported filters
 
 ### Array based
@@ -74,6 +78,14 @@ String filters allow defining only a single possible value.
 - `store`: require item to be in a specific shop
   - possible values: `credits`, `marks`
   - example: `"store": "marks"`
+
+### Meta
+
+In addition there are some fields that are not filters, but instead allow additional customization
+
+- `color`: color the matching item with this color (values are picked from the topmost rule that the item matches)
+  - possible values: any HTML color code, e.g. `"blue"`, `#ff5733`
+  - example: `"color": "#ff5733"`
 
 ## Default configuration
 

--- a/src/components/Store.tsx
+++ b/src/components/Store.tsx
@@ -15,13 +15,14 @@ import localisation from "../localisation.json"
 import "./Store.css"
 import { Countdown } from "./Countdown"
 import { ItemState } from "./ItemState"
+import type React from "react"
 
 function Divider() {
   return <hr className="MuiDivider-root MuiDivider-fullWidth css-pj146d" />
 }
 
-function Title({ children }: { children: ReactNode }) {
-  return <div className="item-title">{children}</div>
+function Title({ children, style }: { children: ReactNode, style?: React.CSSProperties}) {
+  return <div className="item-title" style={style}>{children}</div>
 }
 
 // Linearly interpolate input between min and max. E.g. lerp(1, 2, 0.5) returns 1.5
@@ -180,7 +181,7 @@ function filterFunc(
 
   let arr: string[]
 
-  var found = targets.find(function (target) {
+  var found = targets.findIndex(function (target) {
     arr = typeof target.character === 'string' ? [target.character] : target.character
     if (target.character && !arr.includes(char.archetype)) {
       return false
@@ -303,11 +304,7 @@ function filterFunc(
     return true
   })
 
-  if (found) {
-    offer.description.overrides.filter_match = true
-  } else {
-    offer.description.overrides.filter_match = false
-  }
+  offer.description.overrides.filter_match = found
 }
 
 export function Store({
@@ -368,17 +365,20 @@ export function Store({
           let alreadyOwnedClass =
             offer.state === "completed" ? "item-already-owned" : ""
           let filterMatchClass = enableRuleBasedFilterOption
-            ? offer.description.overrides.filter_match
-              ? "offer-match"
+            ? offer.description.overrides.filter_match && offer.description.overrides.filter_match >= 0
+              ? `offer-match match-rule-${offer.description.overrides.filter_match}`
               : deemphasizeClass[deemphasizeOption]
             : ""
+          let filterMatchStyle = enableRuleBasedFilterOption && offer.description.overrides.filter_match >= 0
+            ? {color: targets[offer.description.overrides.filter_match].color}
+            : undefined
 
           return (
             <div
               className={`MuiBox-root css-178yklu item-container ${filterMatchClass} ${alreadyOwnedClass}`}
               key={offer.offerId}
             >
-              <Title>{localisation[offer.description.id].display_name}</Title>
+              <Title style={filterMatchStyle}>{localisation[offer.description.id].display_name}</Title>
 
               {offer.state === "completed" ? (
                 <ItemState>You already own this</ItemState>

--- a/src/components/Store.tsx
+++ b/src/components/Store.tsx
@@ -224,8 +224,6 @@ function filterFunc(
       }
     }
 
-
-
     if (target.minStats && target.minStats > offer.description.overrides.baseItemLevel) {
       return false
     }
@@ -365,14 +363,13 @@ export function Store({
           let alreadyOwnedClass =
             offer.state === "completed" ? "item-already-owned" : ""
           let filterMatchClass = enableRuleBasedFilterOption
-            ? offer.description.overrides.filter_match && offer.description.overrides.filter_match >= 0
+            ? offer.description.overrides.filter_match >= 0
               ? `offer-match match-rule-${offer.description.overrides.filter_match}`
               : deemphasizeClass[deemphasizeOption]
             : ""
           let filterMatchStyle = enableRuleBasedFilterOption && offer.description.overrides.filter_match >= 0
             ? {color: targets[offer.description.overrides.filter_match].color}
             : undefined
-
           return (
             <div
               className={`MuiBox-root css-178yklu item-container ${filterMatchClass} ${alreadyOwnedClass}`}

--- a/src/types.ts
+++ b/src/types.ts
@@ -98,7 +98,7 @@ export interface Overrides {
   traits: Trait[]
   perks: Perk[]
   base_stats?: BaseStat[]
-  filter_match?: number // index of rule, or undefined/-1 if didn't match any?
+  filter_match?: number // index of the first rule that the item matched to
 }
 
 export interface BaseStat {

--- a/src/types.ts
+++ b/src/types.ts
@@ -98,7 +98,7 @@ export interface Overrides {
   traits: Trait[]
   perks: Perk[]
   base_stats?: BaseStat[]
-  filter_match?: boolean
+  filter_match?: number // index of rule, or undefined/-1 if didn't match any?
 }
 
 export interface BaseStat {
@@ -220,6 +220,7 @@ export interface FilterRule {
   minPerkRarity?: number
   minStats?: number
   minRating?: number
+  color?: string
 }
 
 export const STORE_TYPES = ["credits", "marks"] as const


### PR DESCRIPTION
As the title says, this allows defining different colors for different rules.

Main question that's left is probably if things like `color` and future `alert` (or whatever it ends up being named) should be like they are now or separated a bit... something like:

```
    {
        "store": "marks",
        "color": "white"
    }
```

vs 

```
    {
        "store": "marks",
        "meta": { 
          "color": "white"
        }
    }
```
